### PR TITLE
fix: The instructions for quiz did not appear

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "ember-data": "^2.3.0",
     "ember-disable-proxy-controllers": "^1.0.1",
     "ember-export-application-global": "^1.0.4",
-    "ember-resolver": "^2.0.3"
+    "ember-resolver": "^2.0.3",
+    "ember-inflector": "2.2.0"
   }
 }


### PR DESCRIPTION
Add "ember-inflector": "2.2.0" to the dependencies for npm